### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     eventmachine (1.2.5)
     i18n (0.8.6)
     minitest (5.10.1)
-    rack (2.0.3)
+    rack (2.0.6)
     rack-cors (1.0.2)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)


### PR DESCRIPTION
Remediation

Upgrade rack to version 2.0.6 or later. For example:

gem "rack", ">= 2.0.6"

Always verify the validity and compatibility of suggestions with your codebase.
Details
CVE-2018-16471 More information
moderate severity
Vulnerable versions: >= 2.0.0, < 2.0.6
Patched version: 2.0.6

There is a possible XSS vulnerability in Rack before 2.0.6 and 1.6.11. Carefully crafted requests can impact the data returned by the scheme method on Rack::Request. Applications that expect the scheme to be limited to 'http' or 'https' and do not escape the return value could be vulnerable to an XSS attack. Note that applications using the normal escaping mechanisms provided by Rails may not impacted, but applications that bypass the escaping mechanisms, or do not use them may be vulnerable.